### PR TITLE
Specify ruamel.yaml when installing from pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [v0.5.0] - 2021-02-11 - v0.5.0
 
-- Switched from `pyyaml` to `ruamel`.
+- Switched from `pyyaml` to `ruamel.yaml`.
 
 ## [v0.4.0] - 2021-02-10 - v0.4.0
 

--- a/plistyamlplist_lib/plist_yaml.py
+++ b/plistyamlplist_lib/plist_yaml.py
@@ -36,7 +36,7 @@ except ImportError:
             "pip",
             "setuptools",
             "wheel",
-            "ruamel",
+            "ruamel.yaml",
             "--user",
         ]
     )

--- a/plistyamlplist_lib/yaml_plist.py
+++ b/plistyamlplist_lib/yaml_plist.py
@@ -36,7 +36,7 @@ except ImportError:
             "pip",
             "setuptools",
             "wheel",
-            "ruamel",
+            "ruamel.yaml",
             "--user",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ setup(
     name="plistyamlplist",
     version="0.5.0",
     packages=find_packages(include=["plistyamlplist_lib", "plistyamlplist_lib.*"]),
-    install_requires=["ruamel"],
+    install_requires=["ruamel.yaml"],
 )


### PR DESCRIPTION
Without this specificity, the following error occurs:

```
ERROR: Could not find a version that satisfies the requirement ruamel
ERROR: No matching distribution found for ruamel
```