### PR TITLE
Update autopkg handling to retain trust info

### DIFF
--- a/plistyamlplist_lib/handle_autopkg_recipes.py
+++ b/plistyamlplist_lib/handle_autopkg_recipes.py
@@ -41,6 +41,7 @@ def optimise_autopkg_recipes(recipe):
         "MinimumVersion",
         "Input",
         "Process",
+        "ParentRecipeTrustInfo",
     ]
     desired_list = [k for k in desired_order if k in recipe]
     reordered_recipe = {k: recipe[k] for k in desired_list}
@@ -52,7 +53,7 @@ def format_autopkg_recipes(output):
     """Add lines between Input and Process, and between multiple processes.
     This aids readability of yaml recipes"""
     # add line before specific processors
-    for item in ["Input:", "Process:", "- Processor:"]:
+    for item in ["Input:", "Process:", "- Processor:", "ParentRecipeTrustInfo:"]:
         output = output.replace(item, "\n" + item)
 
     # remove line before first process


### PR DESCRIPTION
Adding `ParentRecipeTrustInfo` to the `desired_order` dict so that when autopkg recipes are converted or tidied, the Trust Info is retained. Also adding this to the processors which gain a new line before them for readability.