### PR TITLE
Add basic unit tests, use context managers, and consolidate duplicate functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,32 @@
-.idea/*
+# IDE
+.idea/
+.vscode/
+
+# Editor
 *.swp
+*.swo
+*~
+
+# macOS
 .DS_Store
+
+# Python
 *.pyc
+*.pyo
+__pycache__/
+*.egg-info/
+.venv/
+venv/
+.env
+env/
+
+# Build artifacts
+build/
+dist/
+*.pkg
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [unreleased]
 
-Changes since last release will be listed here.
+- Added unit tests to project.
 
 ## [v0.6.4] - 2022-06-21 - v0.6.4
 
 - Fixed the installation of ruamel.yaml if not already present.
-- Limit the ruamel.yaml version to less than 0.18.0, because newer versions are completely changed so will need more work to fix. Note that if you already have a newer version of ruamel.yaml in the python that you are using, it is advised to run the following command to remove it, after which running this script will reinstall a working version: 
+- Limit the ruamel.yaml version to less than 0.18.0, because newer versions are completely changed so will need more work to fix. Note that if you already have a newer version of ruamel.yaml in the python that you are using, it is advised to run the following command to remove it, after which running this script will reinstall a working version:
 
 ```
 /path/to/your/python -m pip uninstall ruamel.yaml

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ You can also carry out reformatting of existing `yaml` recipes using the `yaml_t
   # this will process all .recipe.yaml files in the folders within /path/to/_YAML/subfolder
   ```
 
+## Testing
+
+This project includes unit tests to verify the core conversion functionality. To run these tests:
+
+```bash
+python -m unittest discover tests -v
+```
+
 ## Credits
 
 Elements of these scripts come from:

--- a/plistyamlplist_lib/__init__.py
+++ b/plistyamlplist_lib/__init__.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Shared utilities for plist-yaml-plist conversion library.
+"""
+
+try:
+    from ruamel.yaml.nodes import MappingNode
+    from ruamel.yaml import dump, add_representer
+    from collections import OrderedDict
+except ImportError:
+    # Handle case where ruamel.yaml is not available
+    MappingNode = None
+    dump = None
+    add_representer = None
+    OrderedDict = None
+
+
+def represent_ordereddict(dumper, data):
+    """
+    Custom representer for OrderedDict objects in YAML output.
+
+    This function ensures that OrderedDict objects maintain their key order
+    when converted to YAML format, which is crucial for preserving the
+    structure of plist files.
+
+    Args:
+        dumper: The YAML dumper object
+        data: OrderedDict to be represented
+
+    Returns:
+        MappingNode: A YAML mapping node preserving the original order
+    """
+    if MappingNode is None:
+        raise ImportError("ruamel.yaml is required for YAML processing")
+
+    value = []
+
+    for item_key, item_value in data.items():
+        node_key = dumper.represent_data(item_key)
+        node_value = dumper.represent_data(item_value)
+
+        value.append((node_key, node_value))
+
+    return MappingNode("tag:yaml.org,2002:map", value)
+
+
+def convert_to_yaml(data):
+    """
+    Convert data to YAML format with OrderedDict support.
+
+    This function converts Python data structures to YAML format while
+    preserving the order of OrderedDict objects. It's used by both
+    plist_yaml and yaml_tidy modules for consistent YAML output.
+
+    Args:
+        data: Python data structure to convert to YAML
+
+    Returns:
+        str: YAML representation of the data
+
+    Raises:
+        ImportError: If ruamel.yaml is not available
+    """
+    if dump is None or add_representer is None or OrderedDict is None:
+        raise ImportError("ruamel.yaml is required for YAML processing")
+
+    add_representer(OrderedDict, represent_ordereddict)
+    return dump(data, width=float("inf"), default_flow_style=False)

--- a/plistyamlplist_lib/json_plist.py
+++ b/plistyamlplist_lib/json_plist.py
@@ -52,16 +52,15 @@ def json_plist(in_path, out_path):
     except IOError:
         print("ERROR: {} not found".format(in_path))
         return
+    output = convert(input_data)
+
     try:
-        out_file = open(out_path, "w")
+        with open(out_path, "w") as out_file:
+            out_file.writelines(output)
+        print("Wrote to : {}\n".format(out_path))
     except IOError:
         print("ERROR: could not create {} ".format(out_path))
         return
-
-    output = convert(input_data)
-
-    out_file.writelines(output)
-    print("Wrote to : {}\n".format(out_path))
 
 
 def main():

--- a/plistyamlplist_lib/plist_yaml.py
+++ b/plistyamlplist_lib/plist_yaml.py
@@ -48,18 +48,8 @@ except ImportError:
     from ruamel.yaml.nodes import MappingNode
 
 from . import handle_autopkg_recipes
-
-
-def represent_ordereddict(dumper, data):
-    value = []
-
-    for item_key, item_value in data.items():
-        node_key = dumper.represent_data(item_key)
-        node_value = dumper.represent_data(item_value)
-
-        value.append((node_key, node_value))
-
-    return MappingNode("tag:yaml.org,2002:map", value)
+from . import represent_ordereddict
+from . import convert_to_yaml
 
 
 def normalize_types(input_data):
@@ -85,12 +75,6 @@ def normalize_types(input_data):
     return input_data
 
 
-def convert(xml):
-    """Do the conversion."""
-    add_representer(OrderedDict, represent_ordereddict)
-    return dump(xml, width=float("inf"), default_flow_style=False)
-
-
 def plist_yaml(in_path, out_path):
     """Convert plist to yaml."""
     with open(in_path, "rb") as in_file:
@@ -101,10 +85,10 @@ def plist_yaml(in_path, out_path):
     # handle conversion of AutoPkg recipes
     if sys.version_info.major == 3 and in_path.endswith((".recipe", ".recipe.plist")):
         normalized = handle_autopkg_recipes.optimise_autopkg_recipes(normalized)
-        output = convert(normalized)
+        output = convert_to_yaml(normalized)
         output = handle_autopkg_recipes.format_autopkg_recipes(output)
     else:
-        output = convert(normalized)
+        output = convert_to_yaml(normalized)
 
     out_file = open(out_path, "w")
     out_file.writelines(output)

--- a/plistyamlplist_lib/plist_yaml.py
+++ b/plistyamlplist_lib/plist_yaml.py
@@ -90,8 +90,8 @@ def plist_yaml(in_path, out_path):
     else:
         output = convert_to_yaml(normalized)
 
-    out_file = open(out_path, "w")
-    out_file.writelines(output)
+    with open(out_path, "w") as out_file:
+        out_file.writelines(output)
     print("Wrote to : {}\n".format(out_path))
 
 

--- a/plistyamlplist_lib/yaml_plist.py
+++ b/plistyamlplist_lib/yaml_plist.py
@@ -53,21 +53,21 @@ def convert(data):
 def yaml_plist(in_path, out_path):
     """Convert yaml to plist."""
     try:
-        in_file = open(in_path, "r")
+        with open(in_path, "r") as in_file:
+            input_data = yaml.safe_load(in_file)
     except IOError:
         print("ERROR: could not find " + in_path + "\n")
         return
+
+    output = convert(input_data)
+
     try:
-        out_file = open(out_path, "w")
+        with open(out_path, "w") as out_file:
+            out_file.writelines(output)
+        print("Written to " + out_path + "\n")
     except IOError:
         print("ERROR: could not create " + out_path + "\n")
         return
-
-    input_data = yaml.safe_load(in_file)
-    output = convert(input_data)
-
-    out_file.writelines(output)
-    print("Written to " + out_path + "\n")
 
 
 def main():

--- a/plistyamlplist_lib/yaml_tidy.py
+++ b/plistyamlplist_lib/yaml_tidy.py
@@ -40,24 +40,8 @@ except ImportError:
     from ruamel.yaml.constructor import DuplicateKeyError
 
 from . import handle_autopkg_recipes
-
-
-def represent_ordereddict(dumper, data):
-    value = []
-
-    for item_key, item_value in data.items():
-        node_key = dumper.represent_data(item_key)
-        node_value = dumper.represent_data(item_value)
-
-        value.append((node_key, node_value))
-
-    return MappingNode("tag:yaml.org,2002:map", value)
-
-
-def convert(xml):
-    """Do the conversion."""
-    add_representer(OrderedDict, represent_ordereddict)
-    return dump(xml, width=float("inf"), default_flow_style=False)
+from . import represent_ordereddict
+from . import convert_to_yaml
 
 
 def tidy_yaml(in_path, out_path=""):
@@ -81,10 +65,10 @@ def tidy_yaml(in_path, out_path=""):
     # handle conversion of AutoPkg recipes
     if sys.version_info.major == 3 and in_path.endswith(".recipe.yaml"):
         input_data = handle_autopkg_recipes.optimise_autopkg_recipes(input_data)
-        output = convert(input_data)
+        output = convert_to_yaml(input_data)
         output = handle_autopkg_recipes.format_autopkg_recipes(output)
     else:
-        output = convert(input_data)
+        output = convert_to_yaml(input_data)
 
     if not out_path:
         out_path = in_path

--- a/plistyamlplist_lib/yaml_tidy.py
+++ b/plistyamlplist_lib/yaml_tidy.py
@@ -51,13 +51,11 @@ def tidy_yaml(in_path, out_path=""):
         return
 
     try:
-        in_file = open(in_path, "r")
+        with open(in_path, "r") as in_file:
+            input_data = safe_load(in_file)
     except IOError:
         print("ERROR: {} not found".format(in_path))
         return
-
-    try:
-        input_data = safe_load(in_file)
     except DuplicateKeyError:
         print("ERROR: Duplicate key found in {}\n".format(in_path))
         return
@@ -73,13 +71,12 @@ def tidy_yaml(in_path, out_path=""):
     if not out_path:
         out_path = in_path
     try:
-        out_file = open(out_path, "w")
+        with open(out_path, "w") as out_file:
+            out_file.writelines(output)
+        print("Wrote to : {}\n".format(out_path))
     except IOError:
         print("ERROR: could not create {} ".format(out_path))
         return
-    else:
-        out_file.writelines(output)
-        print("Wrote to : {}\n".format(out_path))
 
 
 def main():

--- a/tests/test_data/complex_sample.json
+++ b/tests/test_data/complex_sample.json
@@ -1,0 +1,46 @@
+{
+    "application": {
+        "name": "Complex Test App",
+        "version": "2.1.0",
+        "build": 42,
+        "features": [
+            "authentication",
+            "logging",
+            "monitoring"
+        ]
+    },
+    "configuration": {
+        "database": {
+            "host": "localhost",
+            "port": 5432,
+            "ssl": true,
+            "timeout": null
+        },
+        "cache": {
+            "enabled": true,
+            "size": 100,
+            "ttl": 3600
+        },
+        "logging": {
+            "level": "INFO",
+            "file": "/var/log/app.log",
+            "rotate": true,
+            "max_files": null
+        }
+    },
+    "metadata": {
+        "created": "2023-01-01T00:00:00Z",
+        "modified": null,
+        "tags": [
+            "production",
+            null,
+            "stable",
+            null
+        ],
+        "maintainer": {
+            "name": "Test User",
+            "email": "test@example.com",
+            "active": null
+        }
+    }
+}

--- a/tests/test_data/sample.json
+++ b/tests/test_data/sample.json
@@ -1,0 +1,13 @@
+{
+    "name": "Test Application",
+    "version": "1.0.0",
+    "enabled": true,
+    "settings": {
+        "debug": false,
+        "timeout": 30,
+        "urls": [
+            "https://example.com",
+            "https://test.com"
+        ]
+    }
+}

--- a/tests/test_data/sample.plist
+++ b/tests/test_data/sample.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Test Application</string>
+	<key>version</key>
+	<string>1.0.0</string>
+	<key>enabled</key>
+	<true/>
+	<key>settings</key>
+	<dict>
+		<key>debug</key>
+		<false/>
+		<key>timeout</key>
+		<integer>30</integer>
+		<key>urls</key>
+		<array>
+			<string>https://example.com</string>
+			<string>https://test.com</string>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/tests/test_data/sample.yaml
+++ b/tests/test_data/sample.yaml
@@ -1,0 +1,9 @@
+name: Test Application
+version: 1.0.0
+enabled: true
+settings:
+  debug: false
+  timeout: 30
+  urls:
+    - https://example.com
+    - https://test.com

--- a/tests/test_data/sample_recipe.recipe.yaml
+++ b/tests/test_data/sample_recipe.recipe.yaml
@@ -1,0 +1,23 @@
+Description: Sample AutoPkg Recipe for Testing
+Identifier: com.test.sample
+MinimumVersion: "2.0"
+Input:
+  OTHER_KEY: other_value
+  NAME: SampleApp
+Process:
+- Arguments:
+    source_path: /path/to/source
+    destination_path: /path/to/destination
+  Processor: Copier
+  Comment: Copy the application
+- Processor: CodeSignatureVerifier
+  Arguments:
+    input_path: /path/to/app
+    requirement: identifier "com.example.app"
+- Processor: PkgCreator
+  Arguments:
+    pkg_request:
+      id: com.example.pkg
+      version: "1.0"
+      pkgname: SampleApp
+  Comment: Create the package

--- a/tests/test_handle_autopkg_recipes.py
+++ b/tests/test_handle_autopkg_recipes.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import sys
+from pathlib import Path
+from collections import OrderedDict
+
+# Add the parent directory to the path so we can import the modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from plistyamlplist_lib.handle_autopkg_recipes import (
+    optimise_autopkg_recipes,
+    format_autopkg_recipes,
+)
+
+
+class TestOptimiseAutopkgRecipes(unittest.TestCase):
+    """Test the optimise_autopkg_recipes function."""
+
+    def test_basic_recipe_optimization(self):
+        """Test basic recipe optimization with Process and Input."""
+        recipe = {
+            "Description": "Test recipe",
+            "Identifier": "com.test.recipe",
+            "Process": [
+                {
+                    "Arguments": {"arg1": "value1"},
+                    "Processor": "TestProcessor",
+                    "Comment": "Test comment",
+                }
+            ],
+            "Input": {"OTHER_KEY": "other_value", "NAME": "TestApp"},
+        }
+
+        result = optimise_autopkg_recipes(recipe)
+
+        # Check that Process is reordered (Processor first, Comment and Arguments last)
+        process_item = result["Process"][0]
+        keys = list(process_item.keys())
+        self.assertEqual(keys[0], "Processor")
+        self.assertEqual(keys[-2], "Comment")
+        self.assertEqual(keys[-1], "Arguments")
+
+        # Check that Input has NAME first
+        input_keys = list(result["Input"].keys())
+        self.assertEqual(input_keys[0], "NAME")
+
+        # Check overall order
+        recipe_keys = list(result.keys())
+        self.assertEqual(recipe_keys[0], "Description")
+        self.assertEqual(recipe_keys[1], "Identifier")
+        self.assertIn("Input", recipe_keys)
+        self.assertIn("Process", recipe_keys)
+
+    def test_recipe_without_process(self):
+        """Test recipe optimization when Process is missing."""
+        recipe = {
+            "Description": "Test recipe",
+            "Input": {"OTHER_KEY": "other_value", "NAME": "TestApp"},
+        }
+
+        result = optimise_autopkg_recipes(recipe)
+
+        # Should still work and reorder Input
+        input_keys = list(result["Input"].keys())
+        self.assertEqual(input_keys[0], "NAME")
+
+    def test_recipe_without_input(self):
+        """Test recipe optimization when Input is missing."""
+        recipe = {
+            "Description": "Test recipe",
+            "Process": [{"Processor": "TestProcessor"}],
+        }
+
+        result = optimise_autopkg_recipes(recipe)
+
+        # Should still work and reorder Process
+        self.assertIn("Process", result)
+        self.assertEqual(result["Process"][0]["Processor"], "TestProcessor")
+
+    def test_recipe_without_name_in_input(self):
+        """Test recipe optimization when Input doesn't have NAME."""
+        recipe = {
+            "Description": "Test recipe",
+            "Input": {"OTHER_KEY": "other_value", "ANOTHER_KEY": "another_value"},
+        }
+
+        result = optimise_autopkg_recipes(recipe)
+
+        # Should still work without NAME
+        self.assertIn("Input", result)
+        self.assertIn("OTHER_KEY", result["Input"])
+
+    def test_desired_order_enforcement(self):
+        """Test that recipe keys are ordered according to desired_order."""
+        recipe = {
+            "Process": [{"Processor": "TestProcessor"}],
+            "Comment": "Recipe comment",
+            "Input": {"NAME": "TestApp"},
+            "Description": "Test recipe",
+            "Identifier": "com.test.recipe",
+            "MinimumVersion": "1.0",
+        }
+
+        result = optimise_autopkg_recipes(recipe)
+
+        expected_order = [
+            "Comment",
+            "Description",
+            "Identifier",
+            "MinimumVersion",
+            "Input",
+            "Process",
+        ]
+
+        actual_keys = list(result.keys())
+        self.assertEqual(actual_keys, expected_order)
+
+    def test_parent_recipe_trust_info(self):
+        """Test that ParentRecipeTrustInfo is handled correctly."""
+        recipe = {
+            "Description": "Test recipe",
+            "ParentRecipeTrustInfo": {"trust_info": "data"},
+            "Input": {"NAME": "TestApp"},
+        }
+
+        result = optimise_autopkg_recipes(recipe)
+
+        # ParentRecipeTrustInfo should be at the end
+        keys = list(result.keys())
+        self.assertIn("ParentRecipeTrustInfo", keys)
+
+
+class TestFormatAutopkgRecipes(unittest.TestCase):
+    """Test the format_autopkg_recipes function."""
+
+    def test_basic_formatting(self):
+        """Test basic YAML formatting with line breaks."""
+        yaml_input = """Description: Test recipe
+Input:
+  NAME: TestApp
+Process:
+- Processor: TestProcessor
+  Arguments:
+    arg1: value1"""
+
+        result = format_autopkg_recipes(yaml_input)
+
+        # Should add line breaks before Input:, Process:, and - Processor:
+        self.assertIn("\nInput:", result)
+        self.assertIn("\nProcess:", result)
+        # First processor shouldn't have extra line break
+        self.assertNotIn("Process:\n\n-", result)
+
+    def test_newline_conversion_in_strings(self):
+        """Test conversion of quoted strings with newlines to scalars."""
+        yaml_input = 'Description: "Line 1\\nLine 2\\nLine 3"'
+
+        result = format_autopkg_recipes(yaml_input)
+
+        # Should convert to scalar format
+        self.assertIn("Description: |", result)
+        self.assertNotIn("\\n", result)
+
+    def test_tab_conversion(self):
+        """Test conversion of \\t to spaces."""
+        yaml_input = 'Description: "Text with\\ttab"'
+
+        result = format_autopkg_recipes(yaml_input)
+
+        # The function only converts \\t when processing multiline strings with \\n
+        # For simple strings, it leaves them as-is
+        self.assertIn("Description:", result)
+
+    def test_quote_escaping(self):
+        """Test handling of escaped quotes."""
+        yaml_input = 'Description: "Text with \\"quotes\\""'
+
+        result = format_autopkg_recipes(yaml_input)
+
+        # The function only processes quotes when handling multiline strings with \\n
+        # For simple strings, it leaves them as-is
+        self.assertIn("Description:", result)
+        self.assertIn("quotes", result)
+
+    def test_empty_input(self):
+        """Test formatting with empty input."""
+        result = format_autopkg_recipes("")
+
+        # Should return empty string (the function adds a newline at the end)
+        self.assertEqual(result, "")
+
+    def test_multiple_processors(self):
+        """Test formatting with multiple processors."""
+        yaml_input = """Process:
+- Processor: FirstProcessor
+- Processor: SecondProcessor"""
+
+        result = format_autopkg_recipes(yaml_input)
+
+        # Should add line breaks before each processor
+        self.assertIn("\n- Processor: FirstProcessor", result)
+        self.assertIn("\n- Processor: SecondProcessor", result)
+
+    def test_parent_recipe_trust_info_formatting(self):
+        """Test formatting of ParentRecipeTrustInfo."""
+        yaml_input = """Description: Test
+ParentRecipeTrustInfo:
+  trust_data: value"""
+
+        result = format_autopkg_recipes(yaml_input)
+
+        # Should add line break before ParentRecipeTrustInfo
+        self.assertIn("\nParentRecipeTrustInfo:", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_json_plist.py
+++ b/tests/test_json_plist.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import tempfile
+import os
+import sys
+import json
+from pathlib import Path
+
+# Add the parent directory to the path so we can import the modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from plistyamlplist_lib.json_plist import json_plist, clean_nones, convert
+
+
+class TestJsonPlist(unittest.TestCase):
+    """Test json_plist module functions independently."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_data_dir = Path(__file__).parent / "test_data"
+        self.sample_json = self.test_data_dir / "sample.json"
+
+    def test_json_plist_conversion_detailed(self):
+        """Test detailed JSON to plist conversion."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Convert json to plist
+            json_plist(str(self.sample_json), temp_plist_path)
+
+            # Check that output file was created
+            self.assertTrue(os.path.exists(temp_plist_path))
+
+            # Check detailed plist structure
+            with open(temp_plist_path, "r") as f:
+                content = f.read()
+
+                # Check XML structure
+                self.assertIn('<?xml version="1.0"', content)
+                self.assertIn("<!DOCTYPE plist", content)
+                self.assertIn('<plist version="1.0">', content)
+                self.assertIn("</plist>", content)
+
+                # Check data content
+                self.assertIn("<key>name</key>", content)
+                self.assertIn("<string>Test Application</string>", content)
+                self.assertIn("<key>enabled</key>", content)
+                self.assertIn("<true/>", content)
+                self.assertIn("<key>settings</key>", content)
+                self.assertIn("<key>timeout</key>", content)
+                self.assertIn("<integer>30</integer>", content)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_plist_path):
+                os.unlink(temp_plist_path)
+
+    def test_json_plist_with_nonexistent_file(self):
+        """Test json_plist with nonexistent input file."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Should handle gracefully
+            json_plist("/nonexistent/file.json", temp_plist_path)
+
+            # Output file should not be created or should be empty
+            if os.path.exists(temp_plist_path):
+                with open(temp_plist_path, "r") as f:
+                    content = f.read()
+                    # Should be empty or minimal
+                    self.assertEqual(len(content.strip()), 0)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_plist_path):
+                os.unlink(temp_plist_path)
+
+    def test_json_plist_with_invalid_output_path(self):
+        """Test json_plist with invalid output path."""
+        # Should handle gracefully without crashing
+        json_plist(str(self.sample_json), "/invalid/path/output.plist")
+        # No assertion needed - just checking it doesn't crash
+
+    def test_clean_nones_comprehensive(self):
+        """Test clean_nones function comprehensively."""
+        test_data = {
+            "keep_string": "value",
+            "keep_number": 42,
+            "keep_boolean": True,
+            "remove_none": None,
+            "keep_empty_string": "",
+            "keep_zero": 0,
+            "keep_false": False,
+            "nested_dict": {
+                "keep_nested": "nested_value",
+                "remove_nested_none": None,
+                "deeply_nested": {"keep_deep": "deep_value", "remove_deep_none": None},
+            },
+            "list_with_nones": [1, None, "keep", None, 3, None],
+            "empty_list": [],
+            "list_of_dicts": [
+                {"keep": "value1", "remove": None},
+                {"keep": "value2", "remove": None},
+                None,  # This None should be removed
+            ],
+        }
+
+        result = clean_nones(test_data)
+
+        # Check that None values are removed
+        self.assertNotIn("remove_none", result)
+        self.assertNotIn("remove_nested_none", result["nested_dict"])
+        self.assertNotIn("remove_deep_none", result["nested_dict"]["deeply_nested"])
+
+        # Check that non-None values are kept
+        self.assertEqual(result["keep_string"], "value")
+        self.assertEqual(result["keep_number"], 42)
+        self.assertEqual(result["keep_boolean"], True)
+        self.assertEqual(result["keep_empty_string"], "")
+        self.assertEqual(result["keep_zero"], 0)
+        self.assertEqual(result["keep_false"], False)
+
+        # Check nested structures
+        self.assertEqual(result["nested_dict"]["keep_nested"], "nested_value")
+        self.assertEqual(
+            result["nested_dict"]["deeply_nested"]["keep_deep"], "deep_value"
+        )
+
+        # Check list handling
+        self.assertEqual(result["list_with_nones"], [1, "keep", 3])
+        self.assertEqual(result["empty_list"], [])
+
+        # Check list of dicts
+        self.assertEqual(len(result["list_of_dicts"]), 2)  # None item removed
+        self.assertNotIn("remove", result["list_of_dicts"][0])
+        self.assertNotIn("remove", result["list_of_dicts"][1])
+
+    def test_clean_nones_with_primitives(self):
+        """Test clean_nones with primitive values."""
+        # Should return primitive values unchanged
+        self.assertEqual(clean_nones("string"), "string")
+        self.assertEqual(clean_nones(42), 42)
+        self.assertEqual(clean_nones(True), True)
+        self.assertEqual(clean_nones(False), False)
+        self.assertIsNone(clean_nones(None))
+
+    def test_convert_function_detailed(self):
+        """Test convert function with various data types."""
+        test_data = {
+            "string": "test_value",
+            "integer": 123,
+            "float": 45.67,
+            "boolean_true": True,
+            "boolean_false": False,
+            "list": ["item1", "item2", 3],
+            "nested_dict": {"nested_key": "nested_value"},
+        }
+
+        result = convert(test_data)
+
+        # Should return a plist XML string
+        self.assertIsInstance(result, str)
+        self.assertIn('<?xml version="1.0"', result)
+        self.assertIn("<plist", result)
+        self.assertIn("</plist>", result)
+
+        # Check that data is properly encoded
+        self.assertIn("<key>string</key>", result)
+        self.assertIn("<string>test_value</string>", result)
+        self.assertIn("<key>integer</key>", result)
+        self.assertIn("<integer>123</integer>", result)
+        self.assertIn("<key>boolean_true</key>", result)
+        self.assertIn("<true/>", result)
+        self.assertIn("<key>boolean_false</key>", result)
+        self.assertIn("<false/>", result)
+
+    def test_convert_with_none_values(self):
+        """Test convert function after clean_nones processing."""
+        test_data = {"keep": "value", "remove": None}
+
+        # Clean nones first (as done in the actual function)
+        cleaned_data = clean_nones(test_data)
+        result = convert(cleaned_data)
+
+        # Should not contain the None value
+        self.assertNotIn("remove", result)
+        self.assertIn("<key>keep</key>", result)
+        self.assertIn("<string>value</string>", result)
+
+
+class TestJsonPlistIntegration(unittest.TestCase):
+    """Test json_plist integration with actual JSON files."""
+
+    def test_with_complex_json(self):
+        """Test with a more complex JSON structure."""
+        complex_json = {
+            "app_info": {
+                "name": "Complex App",
+                "version": "2.1.0",
+                "features": ["feature1", "feature2", "feature3"],
+            },
+            "settings": {
+                "ui": {"theme": "dark", "language": "en"},
+                "performance": {"cache_size": 100, "timeout": 5000},
+            },
+            "metadata": {
+                "created": "2023-01-01",
+                "modified": None,  # This should be removed
+                "tags": ["tag1", None, "tag2"],  # None should be removed
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as temp_json, tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+
+            json.dump(complex_json, temp_json)
+            temp_json_path = temp_json.name
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Convert complex JSON to plist
+            json_plist(temp_json_path, temp_plist_path)
+
+            # Verify conversion
+            self.assertTrue(os.path.exists(temp_plist_path))
+
+            with open(temp_plist_path, "r") as f:
+                content = f.read()
+
+                # Check structure
+                self.assertIn("<key>app_info</key>", content)
+                self.assertIn("<string>Complex App</string>", content)
+                self.assertIn("<key>features</key>", content)
+                self.assertIn("<array>", content)
+
+                # Check that None values were removed
+                self.assertNotIn("modified", content)
+                # Tags array should only have 2 items (None removed)
+                tag_count = content.count("<string>tag")
+                self.assertEqual(tag_count, 2)
+
+        finally:
+            # Clean up
+            for path in [temp_json_path, temp_plist_path]:
+                if os.path.exists(path):
+                    os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plist_yaml.py
+++ b/tests/test_plist_yaml.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import tempfile
+import os
+import sys
+from pathlib import Path
+
+# Add the parent directory to the path so we can import the modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from plistyamlplist_lib.plist_yaml import plist_yaml, normalize_types
+from plistyamlplist_lib import convert_to_yaml
+from plistyamlplist_lib.yaml_plist import yaml_plist
+from plistyamlplist_lib.json_plist import json_plist, clean_nones
+
+
+class TestPlistYaml(unittest.TestCase):
+    """Test plist to YAML conversion functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_data_dir = Path(__file__).parent / "test_data"
+        self.sample_plist = self.test_data_dir / "sample.plist"
+        self.sample_yaml = self.test_data_dir / "sample.yaml"
+
+    def test_plist_to_yaml_conversion(self):
+        """Test basic plist to YAML conversion."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as temp_yaml:
+            temp_yaml_path = temp_yaml.name
+
+        try:
+            # Convert plist to yaml
+            plist_yaml(str(self.sample_plist), temp_yaml_path)
+
+            # Check that output file was created
+            self.assertTrue(os.path.exists(temp_yaml_path))
+
+            # Check that output file has content
+            with open(temp_yaml_path, "r") as f:
+                content = f.read()
+                self.assertGreater(len(content), 0)
+
+            # Check for expected content
+            self.assertIn("name: Test Application", content)
+            self.assertIn("version: 1.0.0", content)
+            self.assertIn("enabled: true", content)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_yaml_path):
+                os.unlink(temp_yaml_path)
+
+    def test_normalize_types_basic(self):
+        """Test the normalize_types function with basic data types."""
+        test_data = {
+            "string": "test",
+            "number": 42,
+            "boolean": True,
+            "list": [1, 2, 3],
+            "dict": {"nested": "value"},
+        }
+
+        result = normalize_types(test_data)
+
+        # Should return the same data for basic types
+        self.assertEqual(result["string"], "test")
+        self.assertEqual(result["number"], 42)
+        self.assertEqual(result["boolean"], True)
+        self.assertEqual(result["list"], [1, 2, 3])
+        self.assertEqual(result["dict"]["nested"], "value")
+
+    def test_convert_function(self):
+        """Test the convert function produces YAML output."""
+        test_data = {"name": "test", "value": 123}
+
+        result = convert_to_yaml(test_data)
+
+        # Should be a string containing YAML
+        self.assertIsInstance(result, str)
+        self.assertIn("name: test", result)
+        self.assertIn("value: 123", result)
+
+
+class TestYamlPlist(unittest.TestCase):
+    """Test YAML to plist conversion functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_data_dir = Path(__file__).parent / "test_data"
+        self.sample_yaml = self.test_data_dir / "sample.yaml"
+
+    def test_yaml_to_plist_conversion(self):
+        """Test basic YAML to plist conversion."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Convert yaml to plist
+            yaml_plist(str(self.sample_yaml), temp_plist_path)
+
+            # Check that output file was created
+            self.assertTrue(os.path.exists(temp_plist_path))
+
+            # Check that output file has content
+            with open(temp_plist_path, "r") as f:
+                content = f.read()
+                self.assertGreater(len(content), 0)
+
+            # Check for expected plist structure
+            self.assertIn('<?xml version="1.0"', content)
+            self.assertIn("<!DOCTYPE plist", content)
+            self.assertIn('<plist version="1.0">', content)
+            self.assertIn("<key>name</key>", content)
+            self.assertIn("<string>Test Application</string>", content)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_plist_path):
+                os.unlink(temp_plist_path)
+
+
+class TestJsonPlist(unittest.TestCase):
+    """Test JSON to plist conversion functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_data_dir = Path(__file__).parent / "test_data"
+        self.sample_json = self.test_data_dir / "sample.json"
+
+    def test_json_to_plist_conversion(self):
+        """Test basic JSON to plist conversion."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Convert json to plist
+            json_plist(str(self.sample_json), temp_plist_path)
+
+            # Check that output file was created
+            self.assertTrue(os.path.exists(temp_plist_path))
+
+            # Check that output file has content
+            with open(temp_plist_path, "r") as f:
+                content = f.read()
+                self.assertGreater(len(content), 0)
+
+            # Check for expected plist structure
+            self.assertIn('<?xml version="1.0"', content)
+            self.assertIn("<key>name</key>", content)
+            self.assertIn("<string>Test Application</string>", content)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_plist_path):
+                os.unlink(temp_plist_path)
+
+    def test_clean_nones_function(self):
+        """Test the clean_nones function removes None values."""
+        test_data = {
+            "keep": "value",
+            "remove": None,
+            "nested": {"keep": "nested_value", "remove": None},
+            "list": [1, None, 3, None],
+        }
+
+        result = clean_nones(test_data)
+
+        # None values should be removed
+        self.assertNotIn("remove", result)
+        self.assertNotIn("remove", result["nested"])
+        self.assertEqual(result["list"], [1, 3])
+
+        # Non-None values should be kept
+        self.assertEqual(result["keep"], "value")
+        self.assertEqual(result["nested"]["keep"], "nested_value")
+
+
+class TestRoundTripConversions(unittest.TestCase):
+    """Test round-trip conversions to ensure data integrity."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_data_dir = Path(__file__).parent / "test_data"
+        self.sample_plist = self.test_data_dir / "sample.plist"
+
+    def test_plist_yaml_plist_roundtrip(self):
+        """Test plist -> yaml -> plist conversion preserves data."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as temp_yaml, tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+
+            temp_yaml_path = temp_yaml.name
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Convert plist -> yaml -> plist
+            plist_yaml(str(self.sample_plist), temp_yaml_path)
+            yaml_plist(temp_yaml_path, temp_plist_path)
+
+            # Both files should exist and have content
+            self.assertTrue(os.path.exists(temp_yaml_path))
+            self.assertTrue(os.path.exists(temp_plist_path))
+
+            with open(temp_plist_path, "r") as f:
+                final_content = f.read()
+
+            # Should contain the key elements from original
+            self.assertIn("<key>name</key>", final_content)
+            self.assertIn("<string>Test Application</string>", final_content)
+            self.assertIn("<key>enabled</key>", final_content)
+            self.assertIn("<true/>", final_content)
+
+        finally:
+            # Clean up
+            for path in [temp_yaml_path, temp_plist_path]:
+                if os.path.exists(path):
+                    os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shared_utils.py
+++ b/tests/test_shared_utils.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import sys
+from pathlib import Path
+from collections import OrderedDict
+
+# Add the parent directory to the path so we can import the modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from plistyamlplist_lib import represent_ordereddict, convert_to_yaml
+
+# Import YAML components for testing
+try:
+    from ruamel.yaml import YAML
+    from ruamel.yaml.nodes import MappingNode, ScalarNode
+    from ruamel.yaml.representer import RoundTripRepresenter
+except ImportError:
+    # Skip tests if ruamel.yaml is not available
+    YAML = None
+
+
+class MockDumper:
+    """Mock dumper class for testing represent_ordereddict."""
+
+    def __init__(self):
+        self.represented_data = {}
+
+    def represent_data(self, data):
+        """Mock represent_data method that creates ScalarNode for simple data."""
+        if isinstance(data, str):
+            return ScalarNode(tag="tag:yaml.org,2002:str", value=data)
+        elif isinstance(data, int):
+            return ScalarNode(tag="tag:yaml.org,2002:int", value=str(data))
+        elif isinstance(data, bool):
+            # Use Python's string representation for consistency with actual behavior
+            return ScalarNode(tag="tag:yaml.org,2002:bool", value=str(data))
+        elif data is None:
+            return ScalarNode(tag="tag:yaml.org,2002:null", value="null")
+        else:
+            # For complex data, just return a string representation
+            return ScalarNode(tag="tag:yaml.org,2002:str", value=str(data))
+
+
+@unittest.skipIf(YAML is None, "ruamel.yaml not available")
+class TestRepresentOrderedDict(unittest.TestCase):
+    """Test the shared represent_ordereddict utility function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_dumper = MockDumper()
+
+    def test_represent_ordereddict_basic(self):
+        """Test basic functionality of represent_ordereddict."""
+        test_data = OrderedDict(
+            [("first", "value1"), ("second", "value2"), ("third", "value3")]
+        )
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Should return a MappingNode
+        self.assertIsInstance(result, MappingNode)
+
+        # Should have the correct tag
+        self.assertEqual(result.tag, "tag:yaml.org,2002:map")
+
+        # Should have the correct number of key-value pairs
+        self.assertEqual(len(result.value), 3)
+
+        # Check that all pairs are tuples of nodes
+        for pair in result.value:
+            self.assertIsInstance(pair, tuple)
+            self.assertEqual(len(pair), 2)
+            self.assertIsInstance(pair[0], ScalarNode)  # key node
+            self.assertIsInstance(pair[1], ScalarNode)  # value node
+
+    def test_represent_ordereddict_centralized(self):
+        """Test that the centralized represent_ordereddict function works correctly."""
+        test_data = OrderedDict(
+            [("first", "value1"), ("second", "value2"), ("third", "value3")]
+        )
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Should return a MappingNode
+        self.assertIsInstance(result, MappingNode)
+
+        # Should have the correct tag
+        self.assertEqual(result.tag, "tag:yaml.org,2002:map")
+
+        # Should have the correct number of key-value pairs
+        self.assertEqual(len(result.value), 3)
+
+    def test_represent_ordereddict_preserves_order(self):
+        """Test that represent_ordereddict preserves the order of keys."""
+        test_data = OrderedDict(
+            [("zebra", "last"), ("alpha", "first"), ("beta", "second")]
+        )
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Extract the key values from the result
+        key_values = [pair[0].value for pair in result.value]
+
+        # Should maintain the original order
+        expected_order = ["zebra", "alpha", "beta"]
+        self.assertEqual(key_values, expected_order)
+
+    def test_represent_ordereddict_with_different_types(self):
+        """Test represent_ordereddict with different data types."""
+        test_data = OrderedDict(
+            [
+                ("string_key", "string_value"),
+                ("int_key", 42),
+                ("bool_key", True),
+                ("none_key", None),
+            ]
+        )
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Should handle all data types
+        self.assertEqual(len(result.value), 4)
+
+        # Check that each value was properly represented
+        key_value_pairs = [(pair[0].value, pair[1].value) for pair in result.value]
+
+        expected_pairs = [
+            ("string_key", "string_value"),
+            ("int_key", "42"),
+            ("bool_key", "True"),  # Python's str(True) returns "True", not "true"
+            ("none_key", "null"),
+        ]
+
+        self.assertEqual(key_value_pairs, expected_pairs)
+
+    def test_represent_ordereddict_empty(self):
+        """Test represent_ordereddict with empty OrderedDict."""
+        test_data = OrderedDict()
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Should return a MappingNode with empty value list
+        self.assertIsInstance(result, MappingNode)
+        self.assertEqual(result.tag, "tag:yaml.org,2002:map")
+        self.assertEqual(len(result.value), 0)
+        self.assertEqual(result.value, [])
+
+    def test_represent_ordereddict_nested_structure(self):
+        """Test represent_ordereddict with nested data structures."""
+        nested_dict = {"nested_key": "nested_value"}
+        nested_list = ["item1", "item2"]
+
+        test_data = OrderedDict(
+            [("simple", "value"), ("dict", nested_dict), ("list", nested_list)]
+        )
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Should handle nested structures (they get converted to strings by mock dumper)
+        self.assertEqual(len(result.value), 3)
+
+        # Check the keys
+        keys = [pair[0].value for pair in result.value]
+        self.assertEqual(keys, ["simple", "dict", "list"])
+
+    def test_represent_ordereddict_single_item(self):
+        """Test represent_ordereddict with single item."""
+        test_data = OrderedDict([("only_key", "only_value")])
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Should work with single item
+        self.assertEqual(len(result.value), 1)
+        key_node, value_node = result.value[0]
+        self.assertEqual(key_node.value, "only_key")
+        self.assertEqual(value_node.value, "only_value")
+
+    def test_represent_ordereddict_consistency(self):
+        """Test that represent_ordereddict produces consistent results."""
+        test_data = OrderedDict([("key1", "value1"), ("key2", 42), ("key3", True)])
+
+        result1 = represent_ordereddict(self.mock_dumper, test_data)
+        result2 = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Multiple calls should produce identical results
+        self.assertEqual(result1.tag, result2.tag)
+        self.assertEqual(len(result1.value), len(result2.value))
+
+        # Compare each key-value pair
+        for pair1, pair2 in zip(result1.value, result2.value):
+            self.assertEqual(pair1[0].value, pair2[0].value)  # keys
+            self.assertEqual(pair1[1].value, pair2[1].value)  # values
+
+    def test_represent_ordereddict_with_special_characters(self):
+        """Test represent_ordereddict with special characters in keys and values."""
+        test_data = OrderedDict(
+            [
+                ("key with spaces", "value with spaces"),
+                ("key-with-dashes", "value-with-dashes"),
+                ("key_with_underscores", "value_with_underscores"),
+                ("key.with.dots", "value.with.dots"),
+                ("key/with/slashes", "value/with/slashes"),
+            ]
+        )
+
+        result = represent_ordereddict(self.mock_dumper, test_data)
+
+        # Should handle special characters
+        self.assertEqual(len(result.value), 5)
+
+        # Verify all keys and values are preserved
+        for i, (expected_key, expected_value) in enumerate(test_data.items()):
+            key_node, value_node = result.value[i]
+            self.assertEqual(key_node.value, expected_key)
+            self.assertEqual(value_node.value, expected_value)
+
+
+@unittest.skipIf(YAML is None, "ruamel.yaml not available")
+class TestSharedUtilsIntegration(unittest.TestCase):
+    """Integration tests for shared utility functions with actual YAML processing."""
+
+    def test_integration_with_yaml_conversion(self):
+        """Test represent_ordereddict integration with convert_to_yaml function."""
+
+        test_data = OrderedDict(
+            [("first", "alpha"), ("second", "beta"), ("third", "gamma")]
+        )
+
+        # This should use represent_ordereddict internally
+        result = convert_to_yaml(test_data)
+
+        # Should produce valid YAML
+        self.assertIsInstance(result, str)
+        self.assertIn("first: alpha", result)
+        self.assertIn("second: beta", result)
+        self.assertIn("third: gamma", result)
+
+        # Order should be preserved in the output
+        lines = result.strip().split("\n")
+        self.assertTrue(any("first: alpha" in line for line in lines))
+        self.assertTrue(any("second: beta" in line for line in lines))
+        self.assertTrue(any("third: gamma" in line for line in lines))
+
+    def test_integration_with_yaml_tidy_conversion(self):
+        """Test represent_ordereddict integration with centralized convert_to_yaml function."""
+
+        test_data = OrderedDict(
+            [("name", "Test App"), ("version", "1.0.0"), ("enabled", True)]
+        )
+
+        # This should use represent_ordereddict internally
+        result = convert_to_yaml(test_data)
+
+        # Should produce valid YAML
+        self.assertIsInstance(result, str)
+        self.assertIn("name: Test App", result)
+        self.assertIn("version: 1.0.0", result)
+        self.assertIn("enabled: true", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yaml_plist.py
+++ b/tests/test_yaml_plist.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import tempfile
+import os
+import sys
+from pathlib import Path
+
+# Add the parent directory to the path so we can import the modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from plistyamlplist_lib.yaml_plist import yaml_plist, convert
+
+
+class TestYamlPlist(unittest.TestCase):
+    """Test yaml_plist module functions independently."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_data_dir = Path(__file__).parent / "test_data"
+        self.sample_yaml = self.test_data_dir / "sample.yaml"
+
+    def test_yaml_plist_conversion_detailed(self):
+        """Test detailed YAML to plist conversion."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Convert yaml to plist
+            yaml_plist(str(self.sample_yaml), temp_plist_path)
+
+            # Check that output file was created
+            self.assertTrue(os.path.exists(temp_plist_path))
+
+            # Check detailed plist structure
+            with open(temp_plist_path, "r") as f:
+                content = f.read()
+
+                # Check XML structure
+                self.assertIn('<?xml version="1.0"', content)
+                self.assertIn("<!DOCTYPE plist", content)
+                self.assertIn('<plist version="1.0">', content)
+                self.assertIn("</plist>", content)
+
+                # Check data content from sample.yaml
+                self.assertIn("<key>name</key>", content)
+                self.assertIn("<string>Test Application</string>", content)
+                self.assertIn("<key>version</key>", content)
+                self.assertIn("<string>1.0.0</string>", content)
+                self.assertIn("<key>enabled</key>", content)
+                self.assertIn("<true/>", content)
+
+                # Check nested structure
+                self.assertIn("<key>settings</key>", content)
+                self.assertIn("<dict>", content)
+                self.assertIn("<key>debug</key>", content)
+                self.assertIn("<false/>", content)
+                self.assertIn("<key>timeout</key>", content)
+                self.assertIn("<integer>30</integer>", content)
+
+                # Check array structure
+                self.assertIn("<key>urls</key>", content)
+                self.assertIn("<array>", content)
+                self.assertIn("<string>https://example.com</string>", content)
+                self.assertIn("<string>https://test.com</string>", content)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_plist_path):
+                os.unlink(temp_plist_path)
+
+    def test_yaml_plist_with_nonexistent_file(self):
+        """Test yaml_plist with nonexistent input file."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Should handle gracefully and return early
+            yaml_plist("/nonexistent/file.yaml", temp_plist_path)
+
+            # Output file should not contain valid plist data
+            if os.path.exists(temp_plist_path):
+                with open(temp_plist_path, "r") as f:
+                    content = f.read()
+                    # Should be empty or minimal
+                    self.assertEqual(len(content.strip()), 0)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_plist_path):
+                os.unlink(temp_plist_path)
+
+    def test_yaml_plist_with_invalid_output_path(self):
+        """Test yaml_plist with invalid output path."""
+        # Should handle gracefully without crashing
+        yaml_plist(str(self.sample_yaml), "/invalid/path/output.plist")
+        # No assertion needed - just checking it doesn't crash
+
+    def test_convert_function_detailed(self):
+        """Test convert function with various YAML data types."""
+        test_data = {
+            "string": "test_value",
+            "integer": 123,
+            "float": 45.67,
+            "boolean_true": True,
+            "boolean_false": False,
+            "list": ["item1", "item2", 3],
+            "nested_dict": {"nested_key": "nested_value"},
+            # Note: plist format doesn't support None/null values
+        }
+
+        result = convert(test_data)
+
+        # Should return a plist XML string
+        self.assertIsInstance(result, str)
+        self.assertIn('<?xml version="1.0"', result)
+        self.assertIn("<plist", result)
+        self.assertIn("</plist>", result)
+
+        # Check that data is properly encoded
+        self.assertIn("<key>string</key>", result)
+        self.assertIn("<string>test_value</string>", result)
+        self.assertIn("<key>integer</key>", result)
+        self.assertIn("<integer>123</integer>", result)
+        self.assertIn("<key>boolean_true</key>", result)
+        self.assertIn("<true/>", result)
+        self.assertIn("<key>boolean_false</key>", result)
+        self.assertIn("<false/>", result)
+
+        # Check array
+        self.assertIn("<key>list</key>", result)
+        self.assertIn("<array>", result)
+
+        # Check nested dict
+        self.assertIn("<key>nested_dict</key>", result)
+        self.assertIn("<key>nested_key</key>", result)
+
+    def test_yaml_plist_with_custom_yaml(self):
+        """Test yaml_plist with custom YAML content."""
+        yaml_content = """application:
+  name: Custom App
+  version: 3.0.0
+  settings:
+    theme: light
+    notifications: true
+    max_connections: 50
+  features:
+    - authentication
+    - logging
+    - monitoring
+metadata:
+  created_by: test
+  environment: development"""
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as temp_yaml, tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+
+            temp_yaml.write(yaml_content)
+            temp_yaml_path = temp_yaml.name
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Convert custom YAML to plist
+            yaml_plist(temp_yaml_path, temp_plist_path)
+
+            # Verify conversion
+            self.assertTrue(os.path.exists(temp_plist_path))
+
+            with open(temp_plist_path, "r") as f:
+                content = f.read()
+
+                # Check structure
+                self.assertIn("<key>application</key>", content)
+                self.assertIn("<string>Custom App</string>", content)
+                self.assertIn("<key>settings</key>", content)
+                self.assertIn("<integer>50</integer>", content)
+
+                # Check array
+                self.assertIn("<key>features</key>", content)
+                self.assertIn("<array>", content)
+                self.assertIn("<string>authentication</string>", content)
+                self.assertIn("<string>logging</string>", content)
+                self.assertIn("<string>monitoring</string>", content)
+
+                # Check metadata
+                self.assertIn("<key>metadata</key>", content)
+                self.assertIn("<string>development</string>", content)
+
+        finally:
+            # Clean up
+            for path in [temp_yaml_path, temp_plist_path]:
+                if os.path.exists(path):
+                    os.unlink(path)
+
+    def test_yaml_plist_with_malformed_yaml(self):
+        """Test yaml_plist with malformed YAML."""
+        malformed_yaml = """name: Test App
+version: 1.0.0
+settings:
+  debug: true
+    invalid_indentation: bad
+  timeout: 30"""
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as temp_yaml, tempfile.NamedTemporaryFile(
+            mode="w", suffix=".plist", delete=False
+        ) as temp_plist:
+
+            temp_yaml.write(malformed_yaml)
+            temp_yaml_path = temp_yaml.name
+            temp_plist_path = temp_plist.name
+
+        try:
+            # Should raise an exception for malformed YAML
+            with self.assertRaises(Exception):
+                yaml_plist(temp_yaml_path, temp_plist_path)
+
+        finally:
+            # Clean up
+            for path in [temp_yaml_path, temp_plist_path]:
+                if os.path.exists(path):
+                    os.unlink(path)
+
+    def test_convert_with_empty_data(self):
+        """Test convert function with empty data."""
+        result = convert({})
+
+        # Should return valid empty plist
+        self.assertIsInstance(result, str)
+        self.assertIn('<?xml version="1.0"', result)
+        self.assertIn("<plist", result)
+        self.assertIn("<dict/>", result)
+        self.assertIn("</plist>", result)
+
+    def test_convert_with_nested_structures(self):
+        """Test convert function with deeply nested structures."""
+        nested_data = {
+            "level1": {
+                "level2": {
+                    "level3": {"level4": {"deep_value": "found", "deep_number": 42}}
+                }
+            }
+        }
+
+        result = convert(nested_data)
+
+        # Should handle deep nesting
+        self.assertIn("<key>level1</key>", result)
+        self.assertIn("<key>level2</key>", result)
+        self.assertIn("<key>level3</key>", result)
+        self.assertIn("<key>level4</key>", result)
+        self.assertIn("<key>deep_value</key>", result)
+        self.assertIn("<string>found</string>", result)
+        self.assertIn("<integer>42</integer>", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yaml_tidy.py
+++ b/tests/test_yaml_tidy.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import tempfile
+import os
+import sys
+from pathlib import Path
+
+# Add the parent directory to the path so we can import the modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from plistyamlplist_lib.yaml_tidy import tidy_yaml
+from plistyamlplist_lib import convert_to_yaml
+from collections import OrderedDict
+
+
+class TestYamlTidy(unittest.TestCase):
+    """Test the yaml_tidy function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_data_dir = Path(__file__).parent / "test_data"
+
+    def test_tidy_basic_yaml_file(self):
+        """Test tidying a basic YAML file."""
+        # Create a temporary YAML file
+        yaml_content = """name: Test App
+version: 1.0.0
+settings:
+  debug: true
+  timeout: 30"""
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as temp_yaml:
+            temp_yaml.write(yaml_content)
+            temp_yaml_path = temp_yaml.name
+
+        try:
+            # Tidy the YAML file (in-place)
+            tidy_yaml(temp_yaml_path)
+
+            # Check that file still exists and has content
+            self.assertTrue(os.path.exists(temp_yaml_path))
+
+            with open(temp_yaml_path, "r") as f:
+                result = f.read()
+                self.assertGreater(len(result), 0)
+                self.assertIn("name: Test App", result)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_yaml_path):
+                os.unlink(temp_yaml_path)
+
+    def test_tidy_with_output_path(self):
+        """Test tidying with a different output path."""
+        yaml_content = """name: Test App
+version: 1.0.0"""
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as temp_input, tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as temp_output:
+
+            temp_input.write(yaml_content)
+            temp_input_path = temp_input.name
+            temp_output_path = temp_output.name
+
+        try:
+            # Tidy to different output file
+            tidy_yaml(temp_input_path, temp_output_path)
+
+            # Check that output file exists and has content
+            self.assertTrue(os.path.exists(temp_output_path))
+
+            with open(temp_output_path, "r") as f:
+                result = f.read()
+                self.assertIn("name: Test App", result)
+
+        finally:
+            # Clean up
+            for path in [temp_input_path, temp_output_path]:
+                if os.path.exists(path):
+                    os.unlink(path)
+
+    def test_tidy_non_yaml_file(self):
+        """Test that non-YAML files are skipped."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        ) as temp_file:
+            temp_file.write("not yaml content")
+            temp_file_path = temp_file.name
+
+        try:
+            # Should skip non-YAML files
+            tidy_yaml(temp_file_path)
+
+            # File should remain unchanged
+            with open(temp_file_path, "r") as f:
+                content = f.read()
+                self.assertEqual(content, "not yaml content")
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+
+    def test_tidy_nonexistent_file(self):
+        """Test handling of nonexistent files."""
+        # Should handle gracefully without crashing
+        tidy_yaml("/nonexistent/path/file.yaml")
+        # No assertion needed - just checking it doesn't crash
+
+    def test_tidy_autopkg_recipe(self):
+        """Test tidying an AutoPkg recipe file."""
+        recipe_content = """Description: Test AutoPkg Recipe
+Identifier: com.test.recipe
+Input:
+  OTHER_KEY: other_value
+  NAME: TestApp
+Process:
+- Arguments:
+    arg1: value1
+  Processor: TestProcessor
+  Comment: Test comment"""
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".recipe.yaml", delete=False
+        ) as temp_recipe:
+            temp_recipe.write(recipe_content)
+            temp_recipe_path = temp_recipe.name
+
+        try:
+            # Tidy the recipe
+            tidy_yaml(temp_recipe_path)
+
+            # Check that file was processed
+            self.assertTrue(os.path.exists(temp_recipe_path))
+
+            with open(temp_recipe_path, "r") as f:
+                result = f.read()
+                # Should contain the basic elements
+                self.assertIn("Description:", result)
+                self.assertIn("TestApp", result)
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_recipe_path):
+                os.unlink(temp_recipe_path)
+
+
+# Note: convert_to_yaml function is tested comprehensively in test_plist_yaml.py
+# Note: Comprehensive tests for represent_ordereddict are now in test_shared_utils.py
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR includes these changes:

- Duplicate `convert()` and `represent_ordereddict()` functions have been centralized into `__init__.py`
- For reading from and writing to files, `with open()` context managers have been added
- Basic unit tests have been added, focusing on the main logic paths in the project
- Gitignore has been updated to reflect unit tests and related files

These changes will hopefully help increase confidence in your ability to maintain and improve this project. 🍀 

In a virtual environment with all dependencies installed, the unit test output looks like this:

```
(.venv) % python -m unittest discover tests -v
test_basic_formatting (test_handle_autopkg_recipes.TestFormatAutopkgRecipes)
Test basic YAML formatting with line breaks. ... ok
test_empty_input (test_handle_autopkg_recipes.TestFormatAutopkgRecipes)
Test formatting with empty input. ... ok
test_multiple_processors (test_handle_autopkg_recipes.TestFormatAutopkgRecipes)
Test formatting with multiple processors. ... ok
test_newline_conversion_in_strings (test_handle_autopkg_recipes.TestFormatAutopkgRecipes)
Test conversion of quoted strings with newlines to scalars. ... 2
ok
test_parent_recipe_trust_info_formatting (test_handle_autopkg_recipes.TestFormatAutopkgRecipes)
Test formatting of ParentRecipeTrustInfo. ... ok
test_quote_escaping (test_handle_autopkg_recipes.TestFormatAutopkgRecipes)
Test handling of escaped quotes. ... ok
test_tab_conversion (test_handle_autopkg_recipes.TestFormatAutopkgRecipes)
Test conversion of \t to spaces. ... ok
test_basic_recipe_optimization (test_handle_autopkg_recipes.TestOptimiseAutopkgRecipes)
Test basic recipe optimization with Process and Input. ... ok
test_desired_order_enforcement (test_handle_autopkg_recipes.TestOptimiseAutopkgRecipes)
Test that recipe keys are ordered according to desired_order. ... ok
test_parent_recipe_trust_info (test_handle_autopkg_recipes.TestOptimiseAutopkgRecipes)
Test that ParentRecipeTrustInfo is handled correctly. ... ok
test_recipe_without_input (test_handle_autopkg_recipes.TestOptimiseAutopkgRecipes)
Test recipe optimization when Input is missing. ... ok
test_recipe_without_name_in_input (test_handle_autopkg_recipes.TestOptimiseAutopkgRecipes)
Test recipe optimization when Input doesn't have NAME. ... ok
test_recipe_without_process (test_handle_autopkg_recipes.TestOptimiseAutopkgRecipes)
Test recipe optimization when Process is missing. ... ok
test_clean_nones_comprehensive (test_json_plist.TestJsonPlist)
Test clean_nones function comprehensively. ... ok
test_clean_nones_with_primitives (test_json_plist.TestJsonPlist)
Test clean_nones with primitive values. ... ok
test_convert_function_detailed (test_json_plist.TestJsonPlist)
Test convert function with various data types. ... ok
test_convert_with_none_values (test_json_plist.TestJsonPlist)
Test convert function after clean_nones processing. ... ok
test_json_plist_conversion_detailed (test_json_plist.TestJsonPlist)
Test detailed JSON to plist conversion. ... Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpb86bjsl9.plist

ok
test_json_plist_with_invalid_output_path (test_json_plist.TestJsonPlist)
Test json_plist with invalid output path. ... ERROR: could not create /invalid/path/output.plist 
ok
test_json_plist_with_nonexistent_file (test_json_plist.TestJsonPlist)
Test json_plist with nonexistent input file. ... ERROR: /nonexistent/file.json not found
ok
test_with_complex_json (test_json_plist.TestJsonPlistIntegration)
Test with a more complex JSON structure. ... Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmp2a56_27x.plist

ok
test_clean_nones_function (test_plist_yaml.TestJsonPlist)
Test the clean_nones function removes None values. ... ok
test_json_to_plist_conversion (test_plist_yaml.TestJsonPlist)
Test basic JSON to plist conversion. ... Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmp2tfs4mwd.plist

ok
test_convert_function (test_plist_yaml.TestPlistYaml)
Test the convert function produces YAML output. ... ~/Developer/_personal/plist-yaml-plist/plistyamlplist_lib/__init__.py:70: PendingDeprecationWarning: 
dump will be removed, use

  yaml=YAML(typ='unsafe', pure=True)
  yaml.dump(...)

instead
  return dump(data, width=float("inf"), default_flow_style=False)
~/Developer/_personal/plist-yaml-plist/.venv/lib/python3.10/site-packages/ruamel/yaml/main.py:1363: PendingDeprecationWarning: 
dump_all will be removed, use

  yaml=YAML(typ='unsafe', pure=True)
  yaml.dump_all(...)

instead
  return dump_all(
ok
test_normalize_types_basic (test_plist_yaml.TestPlistYaml)
Test the normalize_types function with basic data types. ... ok
test_plist_to_yaml_conversion (test_plist_yaml.TestPlistYaml)
Test basic plist to YAML conversion. ... Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpakufcqo_.yaml

ok
test_plist_yaml_plist_roundtrip (test_plist_yaml.TestRoundTripConversions)
Test plist -> yaml -> plist conversion preserves data. ... Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmp4vxvjbg2.yaml

~/Developer/_personal/plist-yaml-plist/plistyamlplist_lib/yaml_plist.py:57: PendingDeprecationWarning: 
safe_load will be removed, use

  yaml=YAML(typ='safe', pure=True)
  yaml.load(...)

instead
  input_data = yaml.safe_load(in_file)
~/Developer/_personal/plist-yaml-plist/.venv/lib/python3.10/site-packages/ruamel/yaml/main.py:1111: PendingDeprecationWarning: 
load will be removed, use

  yaml=YAML(typ='unsafe', pure=True)
  yaml.load(...)

instead
  return load(stream, SafeLoader, version)
Written to /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpm7j83cdr.plist

ok
test_yaml_to_plist_conversion (test_plist_yaml.TestYamlPlist)
Test basic YAML to plist conversion. ... Written to /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmp58u053zb.plist

ok
test_represent_ordereddict_basic (test_shared_utils.TestRepresentOrderedDict)
Test basic functionality of represent_ordereddict. ... ok
test_represent_ordereddict_centralized (test_shared_utils.TestRepresentOrderedDict)
Test that the centralized represent_ordereddict function works correctly. ... ok
test_represent_ordereddict_consistency (test_shared_utils.TestRepresentOrderedDict)
Test that represent_ordereddict produces consistent results. ... ok
test_represent_ordereddict_empty (test_shared_utils.TestRepresentOrderedDict)
Test represent_ordereddict with empty OrderedDict. ... ok
test_represent_ordereddict_nested_structure (test_shared_utils.TestRepresentOrderedDict)
Test represent_ordereddict with nested data structures. ... ok
test_represent_ordereddict_preserves_order (test_shared_utils.TestRepresentOrderedDict)
Test that represent_ordereddict preserves the order of keys. ... ok
test_represent_ordereddict_single_item (test_shared_utils.TestRepresentOrderedDict)
Test represent_ordereddict with single item. ... ok
test_represent_ordereddict_with_different_types (test_shared_utils.TestRepresentOrderedDict)
Test represent_ordereddict with different data types. ... ok
test_represent_ordereddict_with_special_characters (test_shared_utils.TestRepresentOrderedDict)
Test represent_ordereddict with special characters in keys and values. ... ok
test_integration_with_yaml_conversion (test_shared_utils.TestSharedUtilsIntegration)
Test represent_ordereddict integration with convert_to_yaml function. ... ok
test_integration_with_yaml_tidy_conversion (test_shared_utils.TestSharedUtilsIntegration)
Test represent_ordereddict integration with centralized convert_to_yaml function. ... ok
test_convert_function_detailed (test_yaml_plist.TestYamlPlist)
Test convert function with various YAML data types. ... ok
test_convert_with_empty_data (test_yaml_plist.TestYamlPlist)
Test convert function with empty data. ... ok
test_convert_with_nested_structures (test_yaml_plist.TestYamlPlist)
Test convert function with deeply nested structures. ... ok
test_yaml_plist_conversion_detailed (test_yaml_plist.TestYamlPlist)
Test detailed YAML to plist conversion. ... Written to /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmp8y_1vtam.plist

ok
test_yaml_plist_with_custom_yaml (test_yaml_plist.TestYamlPlist)
Test yaml_plist with custom YAML content. ... Written to /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpgq_x_w5d.plist

ok
test_yaml_plist_with_invalid_output_path (test_yaml_plist.TestYamlPlist)
Test yaml_plist with invalid output path. ... ERROR: could not create /invalid/path/output.plist

ok
test_yaml_plist_with_malformed_yaml (test_yaml_plist.TestYamlPlist)
Test yaml_plist with malformed YAML. ... ok
test_yaml_plist_with_nonexistent_file (test_yaml_plist.TestYamlPlist)
Test yaml_plist with nonexistent input file. ... ERROR: could not find /nonexistent/file.yaml

ok
test_tidy_autopkg_recipe (test_yaml_tidy.TestYamlTidy)
Test tidying an AutoPkg recipe file. ... ~/Developer/_personal/plist-yaml-plist/plistyamlplist_lib/yaml_tidy.py:55: PendingDeprecationWarning: 
safe_load will be removed, use

  yaml=YAML(typ='safe', pure=True)
  yaml.load(...)

instead
  input_data = safe_load(in_file)
Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpwlp0lz1j.recipe.yaml

ok
test_tidy_basic_yaml_file (test_yaml_tidy.TestYamlTidy)
Test tidying a basic YAML file. ... Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpcvcgxo2o.yaml

ok
test_tidy_non_yaml_file (test_yaml_tidy.TestYamlTidy)
Test that non-YAML files are skipped. ... Not processing /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpwy_vejbv.txt

ok
test_tidy_nonexistent_file (test_yaml_tidy.TestYamlTidy)
Test handling of nonexistent files. ... ERROR: /nonexistent/path/file.yaml not found
ok
test_tidy_with_output_path (test_yaml_tidy.TestYamlTidy)
Test tidying with a different output path. ... Wrote to : /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmps7yb5qvh.yaml

ok

----------------------------------------------------------------------
Ran 52 tests in 0.017s

OK
```

I've added a note in the README about how to run the tests.