### PR TITLE
Add uv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ git clone git@github.com:grahampugh/plist-yaml-plist && cd plist-yaml-plist
 python -m pip install .
 ```
 
-#### uv-managed build and install
+#### Local git repo clone + uv-managed install
 ```
+mkdir -p $HOME/dev && cd $HOME/dev
+git clone https://github.com/grahampugh/plist-yaml-plist && cd plist-yaml-plist
 uv tool install .
-source $HOME/.zshenv
 ```
 
 #### Remote git repo install

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This utility is designed to convert Apple `plist` files to `yaml`, or `yaml` fil
 It can also convert `json` files to `plist`.
 
 ## Installation
+
+
 ### Prerequisites
 
 The python `ruamel.yaml` module is required, which is not installed by default on Macs. You can install it with `pip`, which you may also need to install first. A few other things need to be updated for ruamel to install:
@@ -16,10 +18,26 @@ python -m pip install -U pip setuptools wheel ruamel.yaml<0.18.0 --user
 
 If you do not pre-install `ruamel.yaml`, setup.py will do it for you.
 
+
+#### Prerequisites-alternative: uv managed install
+
+install uv if needed first (using cURL)
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
+```
+
+
 #### Local git repo install
 ```bash
 git clone git@github.com:grahampugh/plist-yaml-plist && cd plist-yaml-plist
 python -m pip install .
+```
+
+#### uv-managed build and install
+```
+uv tool install .
+source $HOME/.zshenv
 ```
 
 #### Remote git repo install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "plistyamlplist"
+version = "0.6.4"
+description = "A tool to convert between plist and yaml formats"
+authors = [
+    { name="Graham Pugh", email="your.email@example.com" }
+]
+dependencies = [
+    "ruamel-yaml<0.18.0",
+]
+
+[project.scripts]
+plistyamlplist = "plistyamlplist:main"
+
+[tool.hatch.build.targets.wheel]
+# section is needed "to determine which files to ship inside the wheel...
+# ...most likely cause of this is that there is no directory that matches the name of your project (plist_yaml_plist).".
+# uv docs and tutorials recommend placing modules in tree under src/<project-name>/ but keeping...
+# ...as is to avoid changing other management systems for now.
+packages = ["plistyamlplist_lib"]
+[tool.hatch.build.targets.wheel.force-include]
+"plistyamlplist.py" = "plistyamlplist.py"


### PR DESCRIPTION
Simplest way I found to add [uv](https://docs.astral.sh/uv/getting-started/installation/) support, and to manage and install the Python app as a command line tool

Adds a pyproject.toml to manage uv settings, and instructions to get it to work

The instruction installs the cli tool in ~/.local/share/uv/tools/plistyamlplist and a symlink to it from ~/.local/bin/plistyamlplist.

~/.local/bin is added to your PATH if you follow the cURL method to install [uv](https://docs.astral.sh/uv/getting-started/installation/).




